### PR TITLE
Add Haris as author in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,8 +55,9 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'agentMet4FoF'
-copyright = '2019, Bang Xiang Yong (UCAM), Björn Ludwig (PTB)'
-author = 'Bang Xiang Yong, Björn Ludwig'
+copyright = '2019, Bang Xiang Yong (UCAM), Björn Ludwig (PTB), Haris Lulic (' \
+            'PTB)'
+author = 'Bang Xiang Yong, Björn Ludwig, Haris Lulic'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This adds Haris Lulic from IMBIH to the authors in the Sphinx output on [Read the Docs](https://agentmet4fof.readthedocs.io/en/include_haris_as_author/#references).