### PR TITLE
Refine agents bind output and add pytorch to requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ ZeMA-machine-learning-tutorials-master
 *.csv
 depracated
 results/
+*.pkl

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -344,10 +344,10 @@ class AgentMET4FOF(Agent):
             Agent(s) to be binded to this agent's output channel
 
         """
-        if "AgentPipeline" in str(type(output_agent).__name__):
+        if isinstance(output_agent, AgentPipeline):
             for agent in output_agent.pipeline[0]:
                 self._bind_output(agent)
-        elif type(output_agent) == list:
+        elif isinstance(output_agent, list):
             for agent in output_agent:
                 self._bind_output(agent)
         else:
@@ -1078,6 +1078,7 @@ class TransformerAgent(AgentMET4FOF):
         else:
             chain = message['from']
         return chain
+
 
 class AgentPipeline:
     def __init__(self, agentNetwork=None,*argv, hyperparameters=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ multiprocess
 h5py
 requests
 plotly
+torch
+torchvision


### PR DESCRIPTION
To work through the pipeline examples, one needs pytorch, so I added it to the [requirements.txt](https://github.com/bangxiangyong/agentMET4FOF/blob/refine_agents_bind_output/requirements.txt). The main purpose of this though is to replace the type checks by more pythonic type checks with `isinstance` as commented in the review of #33 .