### PR TITLE
Fix issues with the PyPI package and other minors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,20 @@
 [![Codecov Badge](https://codecov.io/gh/bangxiangyong/agentMet4FoF/branch/master/graph/badge.svg)](https://codecov.io/gh/bangxiangyong/agentMet4FoF)
 
 # Multi-Agent System for Metrology for Factory of the Future (Met4FoF) Code
-This is supported by European Metrology Programme for Innovation and Research (EMPIR) under the project Metrology for the Factory of the Future (Met4FoF), project number 17IND12. (https://www.ptb.de/empir2018/met4fof/home/)
 
-About
----
- - How can metrological input be incorporated into an agent-based system for addressing uncertainty of machine learning in future manufacturing?
+This is supported by European Metrology Programme for Innovation and Research (EMPIR)
+under the project Metrology for the Factory of the Future (Met4FoF), project number
+17IND12. (https://www.ptb.de/empir2018/met4fof/home/)
+
+## About
+
+ - How can metrological input be incorporated into an agent-based system for
+   addressing uncertainty of machine learning in future manufacturing?
  - Includes agent-based simulation and implementation
  - Readthedocs documentation is available at (https://agentmet4fof.readthedocs.io)
 
-Use agentMET4FOF
----
+## Use agentMET4FOF
+
 
 The easiest way to get started with *agentMET4FOF* is navigating to the folder
 in which you want to create a virtual Python environment (*venv*), create one based
@@ -59,8 +63,8 @@ Now you can visit `http://127.0.0.1:8050/` with any Browser and watch the
 To get some insights and really get going please visit [agentMET4FOF.readthedocs.io
 ](https://agentmet4fof.readthedocs.io/).
 
-Get started developing
----
+## Get started developing
+
 First clone the repository to your local machine as described
 [here](https://help.github.com/en/articles/cloning-a-repository). To get started
 with your present *Anaconda* installation just go to *Anaconda
@@ -92,8 +96,8 @@ and want to customize your agents' network.
 
 Alternatively, watch the tutorial webinar [here](https://github.com/bangxiangyong/agentMET4FOF/releases/download/0.1.0/Met4FoF.MAS.webinar.mp4)
 
-Updates
----
+## Updates
+
  - Implemented base class AgentMET4FOF with built-in agent classes DataStreamAgent, MonitorAgent
  - Implemented class AgentNetwork to start or connect to a agent server
  - Implemented with ZEMA prognosis of Electromechanical cylinder data set as use case 
@@ -103,8 +107,8 @@ Updates
 ## Screenshot of web visualization
 ![Web Screenshot](https://raw.githubusercontent.com/bangxiangyong/agentMET4FOF/develop/docs/screenshot_met4fof.png)
 
-Note
----
+## Note
+
 - In the event of agents not terminating cleanly, run
  
   ```python

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Use agentMET4FOF
 ---
 
 The easiest way to get started with *agentMET4FOF* is navigating to the folder
-in which you want to create a virtual Python environment (*venv*), create one,
-activate it, first install numpy, then install *agentMET4FOF* from PyPI.org and then
-work through the [tutorials](agentMET4FOF_tutorials) or [examples](examples). To do this, issue the
-following commands on your Shell:
+in which you want to create a virtual Python environment (*venv*), create one based
+on Python 3.6 or later, activate it, first install numpy, then install *agentMET4FOF*
+from PyPI.org and then work through the [tutorials](agentMET4FOF_tutorials) or
+[examples](examples). To do this, issue the following commands on your Shell:
 
 ```shell
 $ cd /LOCAL/PATH/TO/ENVS

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Python ... (default, ..., ...)
 [GCC ...] on ...
 Type "help", "copyright", "credits" or "license" for more information.
 >>> from agentMET4FOF_tutorials import tutorial_1_generator_agent
->>> tutorial_1_generator_agent.main()
+>>> tutorial_1_generator_agent.demonstrate_generator_agent_use()
 Starting NameServer...
 Broadcast server running on 0.0.0.0:9091
 NS running on 127.0.0.1:3333 (127.0.0.1)

--- a/agentMET4FOF/dashboard/Dashboard_Control.py
+++ b/agentMET4FOF/dashboard/Dashboard_Control.py
@@ -1,7 +1,7 @@
 import networkx as nx
 
-import agentMET4FOF.agents as agentmet4fof_module
-import agentMET4FOF.streams as datastreammet4fof_module
+from agentMET4FOF import agents as agentmet4fof_module
+from agentMET4FOF import streams as datastreammet4fof_module
 
 
 #global variables access via 'dashboard_ctrl'

--- a/agentMET4FOF_tutorials/tutorial_1_generator_agent.py
+++ b/agentMET4FOF_tutorials/tutorial_1_generator_agent.py
@@ -9,7 +9,7 @@ class SineGeneratorAgent(AgentMET4FOF):
     to connected agents via its output channel.
     """
 
-    # Publish the privateThe datatype of the stream will be a
+    # The datatype of the stream will be SineGenerator.
     _sine_stream: SineGenerator
 
     def init_parameters(self):

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
     - defaults
     - conda-forge
 dependencies:
-    - python >=3.5
+    - python >=3.6
     # pip dependencies have to be provided in `requirements.txt` syntax
     - pip:
         - -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,11 @@ setup(
     author_email="bxy20@cam.ac.uk",
     keywords="uncertainty metrology MAS agent-based agents",
     packages=find_packages(exclude=["tests"]),
+    project_urls={
+        "Documentation": "https://agentmet4fof.readthedocs.io/",
+        "Source": "https://github.com/bangxiangyong/agentMET4FOF",
+        "Tracker": "https://github.com/bangxiangyong/agentMET4FOF/issues",
+    },
     install_requires=[
         "ipykernel",
         "numpy",
@@ -69,12 +74,19 @@ setup(
         "requests",
         "plotly",
     ],
-    python_requires=">=3",
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Topic :: Utilities",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Intended Audience :: Education",
+        "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     cmdclass={"verify": VerifyVersionCommand,},
 )


### PR DESCRIPTION
Several issues just recently occured, which we solve in this PR:

- we used type annotations which are not compatible with Python 3.5 anymore, so we require Python 3.6 in the _README.md_, the _environment.yml_ and the _setup.py_
- introduce a `__init__.py` in the package `develop`
- fix two import statements in _Dashboard_Control.py_ which did not work with Python 3.6
- Correct a comment about a type hint in *tutorial_1_generator_agent.py*
- Correct the call for the tutorial in the README.md