### PR TITLE
Exchange multiprocess by official multiprocessing

### DIFF
--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 import networkx as nx
 # ML dependencies
 import numpy as np
-from multiprocess.context import Process
+from multiprocessing.context import Process
 from osbrain import Agent
 from osbrain import NSProxy
 from osbrain import run_agent

--- a/docs/sphinx-requirements.txt
+++ b/docs/sphinx-requirements.txt
@@ -9,7 +9,6 @@ osbrain
 dash
 dash_cytoscape
 networkx
-multiprocess
 plotly
 nbsphinx
 recommonmark

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ osbrain
 dash
 dash_cytoscape
 networkx
-multiprocess
 plotly
 torch
 torchvision

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(
         "dash",
         "dash_cytoscape",
         "networkx",
-        "multiprocess",
         "plotly",
     ],
     python_requires=">=3.6",


### PR DESCRIPTION
Here we are investigating the issue #58 . If this is successful we either know why we use the fork [`multiprocess`](https://pypi.org/project/multiprocess/) over built-in [`multiprocessing`](https://docs.python.org/3/library/multiprocessing.html) and have a test, ensuring that everything works as expected with `multiprocess` and fails by mocking `multiprocessing`, so we notice the moment when we could switch to the preferable built-in library. Otherwise we should switch right away and will do this here to resolve #58 .