### PR TITLE
Select different conversion modes of send_plot for matplotlib figures

### DIFF
--- a/agentMET4FOF/dashboard/Dashboard_agt_net.py
+++ b/agentMET4FOF/dashboard/Dashboard_agt_net.py
@@ -426,15 +426,15 @@ def prepare_agt_net_callbacks(app):
             html_div_monitor.append(html.H5(agent_name, style={"text-align": "center"}))
             # create a new graph for every agent
             for from_agent_name in plot_data:
-                # get the 'data' relevant to 'monitor_agent_input'
-                input_data = plot_data[from_agent_name]
+                # get the graph relevant to 'monitor_agent_input'
+                graph = plot_data[from_agent_name]
 
-                if type(input_data).__name__ == 'dict':
-                    for key in input_data.keys():
-                        new_graph = _handle_matplotlib_figure(input_data[key], from_agent_name)
+                if isinstance(graph, dict):
+                    for graph_ in graph.values():
+                        new_graph = _handle_matplotlib_figure(graph_, from_agent_name)
                         html_div_monitor.append(new_graph)
                 else:
-                    new_graph = _handle_matplotlib_figure(input_data, from_agent_name)
+                    new_graph = _handle_matplotlib_figure(graph, from_agent_name)
                     html_div_monitor.append(new_graph)
 
             #only add the graph if there is some plots in the Monitor Agent

--- a/agentMET4FOF/dashboard/Dashboard_agt_net.py
+++ b/agentMET4FOF/dashboard/Dashboard_agt_net.py
@@ -418,10 +418,16 @@ def prepare_agt_net_callbacks(app):
 
                 if type(input_data).__name__ == 'dict':
                     for key in input_data.keys():
-                        new_graph = html.Img(src=input_data[key], title=from_agent_name)
+                        if isinstance(input_data[key], str):
+                            new_graph = html.Img(src=input_data[key], title=from_agent_name)
+                        else:
+                            new_graph = dcc.Graph(figure=input_data[key])
                         html_div_monitor.append(new_graph)
                 else:
-                    new_graph = html.Img(src=input_data, title=from_agent_name)
+                    if isinstance(input_data, str):
+                        new_graph = html.Img(src=input_data, title=from_agent_name)
+                    else:
+                        new_graph = dcc.Graph(figure=input_data)
                     html_div_monitor.append(new_graph)
 
             #only add the graph if there is some plots in the Monitor Agent

--- a/agentMET4FOF/dashboard/Dashboard_agt_net.py
+++ b/agentMET4FOF/dashboard/Dashboard_agt_net.py
@@ -376,6 +376,19 @@ def prepare_agt_net_callbacks(app):
         # monitor_graphs = monitor_graphs+ [{'displayModeBar': False, 'editable': False, 'scrollZoom':False}]
         return monitor_graphs+ style_graphs
 
+    def _handle_matplotlib_figure(input_data, from_agent_name: str):
+        """
+        Internal function. Checks the mode of matplotlib.figure.Fig to be plotted
+        Either it is a base64 str image, or a plotly graph
+
+        This is used in plotting the received matplotlib figures in the MonitorAgent's plot memory.
+        """
+
+        if isinstance(input_data, str):
+            new_graph = html.Img(src=input_data, title=from_agent_name)
+        else:
+            new_graph = dcc.Graph(figure=input_data)
+        return new_graph
     #load Monitors data and draw - all at once
     @app.callback([dash.dependencies.Output('matplotlib-division', 'children')],
                  [dash.dependencies.Input('interval-update-monitor-graph', 'n_intervals')])
@@ -418,16 +431,10 @@ def prepare_agt_net_callbacks(app):
 
                 if type(input_data).__name__ == 'dict':
                     for key in input_data.keys():
-                        if isinstance(input_data[key], str):
-                            new_graph = html.Img(src=input_data[key], title=from_agent_name)
-                        else:
-                            new_graph = dcc.Graph(figure=input_data[key])
+                        new_graph = _handle_matplotlib_figure(input_data[key], from_agent_name)
                         html_div_monitor.append(new_graph)
                 else:
-                    if isinstance(input_data, str):
-                        new_graph = html.Img(src=input_data, title=from_agent_name)
-                    else:
-                        new_graph = dcc.Graph(figure=input_data)
+                    new_graph = _handle_matplotlib_figure(input_data, from_agent_name)
                     html_div_monitor.append(new_graph)
 
             #only add the graph if there is some plots in the Monitor Agent

--- a/tests/test_send_plot.py
+++ b/tests/test_send_plot.py
@@ -1,4 +1,6 @@
 from agentMET4FOF.agents import AgentMET4FOF, AgentNetwork, MonitorAgent
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
 import time
@@ -28,11 +30,11 @@ class GeneratorAgent(AgentMET4FOF):
 
         cxy, f = axs[1].cohere(s1, s2, 256, 1. / dt)
         axs[1].set_ylabel('coherence')
-        #fig.suptitle('Monitor Agent 1', fontsize=16)
+
         return fig
 
-    def dummy_send_graph(self):
-        self.send_plot(self.create_graph())
+    def dummy_send_graph(self, mode="image"):
+        self.send_plot(self.create_graph(), mode=mode)
 
 def test_send_plot():
     # start agent network server
@@ -44,7 +46,9 @@ def test_send_plot():
 
     agentNetwork.bind_agents(gen_agent, monitor_agent)
 
-    gen_agent.dummy_send_graph()
+    gen_agent.dummy_send_graph(mode="image")
+    time.sleep(3)
+    gen_agent.dummy_send_graph(mode="plotly")
     time.sleep(3)
 
     assert monitor_agent.get_attr('plots')['GeneratorAgent_1']

--- a/tests/test_send_plot_image.py
+++ b/tests/test_send_plot_image.py
@@ -1,0 +1,58 @@
+from agentMET4FOF.agents import AgentMET4FOF, AgentNetwork, MonitorAgent
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+import time
+import plotly.graph_objs
+
+class GeneratorAgent(AgentMET4FOF):
+
+    def create_graph(self):
+        # Fixing random state for reproducibility
+        np.random.seed(19680801)
+
+        dt = 0.01
+        t = np.arange(0, 30, dt)
+        nse1 = np.random.randn(len(t))                 # white noise 1
+        nse2 = np.random.randn(len(t))                 # white noise 2
+
+        # Two signals with a coherent part at 10Hz and a random part
+        s1 = np.sin(2 * np.pi * 10 * t) + nse1
+        s2 = np.sin(2 * np.pi * 10 * t) + nse2
+
+        fig, axs = plt.subplots(2, 1)
+        axs[0].plot(t, s1, t, s2)
+        axs[0].set_xlim(0, 2)
+        axs[0].set_xlabel('time')
+        axs[0].set_ylabel('s1 and s2')
+        axs[0].grid(True)
+
+        cxy, f = axs[1].cohere(s1, s2, 256, 1. / dt)
+        axs[1].set_ylabel('coherence')
+
+        return fig
+
+    def dummy_send_graph(self, mode="image"):
+        self.send_plot(self.create_graph(), mode=mode)
+
+def test_send_plot():
+    # start agent network server
+    agentNetwork = AgentNetwork(dashboard_modules=False)
+
+    # init agents
+    gen_agent = agentNetwork.add_agent(agentType=GeneratorAgent)
+    monitor_agent = agentNetwork.add_agent(agentType=MonitorAgent)
+
+    agentNetwork.bind_agents(gen_agent, monitor_agent)
+
+    gen_agent.dummy_send_graph(mode="image")
+    time.sleep(3)
+
+    assert monitor_agent.get_attr('plots')['GeneratorAgent_1']
+
+    agentNetwork.shutdown()
+
+
+
+

--- a/tests/test_send_plot_plotly.py
+++ b/tests/test_send_plot_plotly.py
@@ -46,8 +46,6 @@ def test_send_plot():
 
     agentNetwork.bind_agents(gen_agent, monitor_agent)
 
-    gen_agent.dummy_send_graph(mode="image")
-    time.sleep(3)
     gen_agent.dummy_send_graph(mode="plotly")
     time.sleep(3)
 


### PR DESCRIPTION
By specifying the `mode` keyword in the agent's send_plot(fig,mode) function, we can select the mechanism of which matplotlib figures can converted and sent to the MonitorAgent to be rendered on the web visualisation. 

if mode == 
1. "image": convert to image
2. "plotly": convert to plotly figure

also modifed the test file to test for both modes of conversion. This should resolve #53 .