### PR TITLE
Experimentally introduce PyDynamic into docs

### DIFF
--- a/docs/PyDynamic interp1d_unc.rst
+++ b/docs/PyDynamic interp1d_unc.rst
@@ -1,0 +1,5 @@
+PyDynamic's interpolation module
+================================
+
+.. automodule:: PyDynamic.uncertainty.interpolation
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
     "sphinx.ext.todo",
     "nbsphinx",
     "recommonmark",
+    "sphinx.ext.intersphinx",
 ]
 
 # This should make SciPy and PyDynamic documentation available inside our docs.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,8 +14,8 @@
 # serve to show the default.
 
 import os
-import sys
 import shutil
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -41,6 +41,13 @@ extensions = [
     "nbsphinx",
     "recommonmark",
 ]
+
+# This should make SciPy and PyDynamic documentation available inside our docs.
+intersphinx_mapping = {
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "PyDynamic": ("https://pydynamic.readthedocs.io/en/latest/", None),
+}
+
 
 nbsphinx_allow_errors = True
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,11 @@ For the *agentMET4FOF* homepage go to
    agentMET4FOF_agents
    agentMET4FOF_streams
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Extensions:
+
+   PyDynamic interp1d_unc.rst
 
 Indices and tables
 ==================

--- a/docs/sphinx-requirements.txt
+++ b/docs/sphinx-requirements.txt
@@ -13,3 +13,4 @@ plotly
 nbsphinx
 recommonmark
 sphinx_rtd_theme
+PyDynamic


### PR DESCRIPTION
This is a proof of concept for the integration of external documentation into a project's ReadTheDocs documentation.

[Check out, how well it works](https://agentmet4fof.readthedocs.io/en/experimentally_introduce_pydynamic_docs/).

But, just to be clear... this is not meant for merging... so, don't touch, just look. :wink: