### PR TITLE
Introduce mpld3 as a mode of rendering matplotlib figures

### DIFF
--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -438,6 +438,22 @@ class AgentMET4FOF(Agent):
         encoded = base64.b64encode(out_img.read()).decode("ascii").replace("\n", "")
         return "data:image/png;base64,{}".format(encoded)
 
+    def _convert_matplotlib_fig(self, fig:matplotlib.figure.Figure, mode:str="image"):
+        """
+        Internal method to convert matplotlib figure which can be rendered by the dashboard.
+
+        """
+        error_msg = "Conversion mode "+mode+" is not implemented."
+        if mode == "plotly":
+            fig = self._convert_to_plotly(fig)
+        elif mode == "image":
+            fig = self._fig_to_uri(fig)
+        elif mode == "mpld3":
+            fig = mpld3.fig_to_dict(fig)
+        else:
+            raise NotImplementedError(error_msg)
+        return fig
+
     def send_plot(self, fig: Union[matplotlib.figure.Figure, Dict[str,matplotlib.figure.Figure]], mode:str ="image"):
         """
         Sends plot to agents connected to this agent's Output channel.
@@ -466,32 +482,15 @@ class AgentMET4FOF(Agent):
 
         """
 
-        error_msg = "Conversion mode "+mode+" is not implemented."
-
         if isinstance(fig, matplotlib.figure.Figure):
-            if mode == "plotly":
-                fig = self._convert_to_plotly(fig)
-            elif mode == "image":
-                fig = self._fig_to_uri(fig)
-            elif mode == "mpld3":
-                fig = mpld3.fig_to_dict(fig)
-            else:
-                raise NotImplementedError(error_msg)
-            graph = {"mode":mode,"fig":fig}
+            graph = {"mode":mode,"fig":self._convert_matplotlib_fig(fig,mode)}
         elif isinstance(fig, dict): #nested
-            if mode == "plotly":
-                for key in fig.keys():
-                    fig[key] = self._convert_to_plotly(fig[key])
-            elif mode == "image":
-                for key in fig.keys():
-                    fig[key] = self._fig_to_uri(fig[key])
-            elif mode == "mpld3":
-                for key in fig.keys():
-                    fig[key] = mpld3.fig_to_dict(fig[key])
-            else:
-                raise NotImplementedError(error_msg)
-            graph = {"mode":mode,"fig":fig}
-        else: #a plotly figure
+            for key in fig.keys():
+                fig[key] = self._convert_matplotlib_fig(fig[key],mode)
+            graph = {"mode":mode,"fig":list(fig.values())}
+        elif isinstance(fig, list):
+            graph = {"mode":mode,"fig":[self._convert_matplotlib_fig(fig_,mode) for fig_ in fig]}
+        else:
             graph = {"mode":mode,"fig":fig}
         self.send_output(graph, channel="plot")
         return graph

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -508,10 +508,10 @@ class AgentMET4FOF(Agent):
             if type is dict, we expect it to be the agentMET4FOF dict message to be compliant with older code
             otherwise, we expect it to be name of agent sender and `data` will need to be passed as parameter
         data
-            optional if agent_from is a dict. Otherwise this parameter is compulsory. Any supported data which can be stored in dict as buffer.
+            optional if agent_from is a dict. Otherwise this parameter is compulsory. Any supported data which can be stored in dict as buffering.
 
         concat_axis : int
-            axis to concatenate on with the buffer for numpy arrays.
+            axis to concatenate on with the buffering for numpy arrays.
 
         """
         # if first argument is the agentMET4FOF dict message
@@ -556,7 +556,7 @@ class AgentMET4FOF(Agent):
         # handle list
         if type(message['data']).__name__ == "list":
             self.memory[message['from']] += message['data']
-            #check if exceed memory buffer size, remove the first n elements which exceeded the size
+            #check if exceed memory buffering size, remove the first n elements which exceeded the size
             if len(self.memory[message['from']]) > self.memory_buffer_size:
                 truncated_element_index = len(self.memory[message['from']]) -self.memory_buffer_size
                 self.memory[message['from']]= self.memory[message['from']][truncated_element_index:]

--- a/agentMET4FOF/agents.py
+++ b/agentMET4FOF/agents.py
@@ -8,6 +8,7 @@ import time
 from typing import Union, Dict, Optional
 import matplotlib.figure
 import matplotlib.pyplot as plt
+import mpld3
 import networkx as nx
 import numpy as np
 from multiprocessing.context import Process
@@ -469,11 +470,14 @@ class AgentMET4FOF(Agent):
 
         if isinstance(fig, matplotlib.figure.Figure):
             if mode == "plotly":
-                graph = self._convert_to_plotly(fig)
+                fig = self._convert_to_plotly(fig)
             elif mode == "image":
-                graph = self._fig_to_uri(fig)
+                fig = self._fig_to_uri(fig)
+            elif mode == "mpld3":
+                fig = mpld3.fig_to_dict(fig)
             else:
                 raise NotImplementedError(error_msg)
+            graph = {"mode":mode,"fig":fig}
         elif isinstance(fig, dict): #nested
             if mode == "plotly":
                 for key in fig.keys():
@@ -481,11 +485,14 @@ class AgentMET4FOF(Agent):
             elif mode == "image":
                 for key in fig.keys():
                     fig[key] = self._fig_to_uri(fig[key])
+            elif mode == "mpld3":
+                for key in fig.keys():
+                    fig[key] = mpld3.fig_to_dict(fig[key])
             else:
                 raise NotImplementedError(error_msg)
-            graph = fig
+            graph = {"mode":mode,"fig":fig}
         else: #a plotly figure
-            graph = fig
+            graph = {"mode":mode,"fig":fig}
         self.send_output(graph, channel="plot")
         return graph
 

--- a/agentMET4FOF/dashboard/Dashboard_agt_net.py
+++ b/agentMET4FOF/dashboard/Dashboard_agt_net.py
@@ -460,19 +460,19 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
             return monitor_graphs+ style_graphs
 
 
-        def _handle_matplotlib_figure(input_data, from_agent_name: str):
+        def _handle_matplotlib_figure(input_data, from_agent_name: str, mode="image"):
             """
             Internal function. Checks the mode of matplotlib.figure.Fig to be plotted
             Either it is a base64 str image, or a plotly graph
 
             This is used in plotting the received matplotlib figures in the MonitorAgent's plot memory.
             """
-            if input_data["mode"] == "plotly":
-                new_graph = dcc.Graph(figure=input_data["fig"])
-            elif input_data["mode"] == "image":
-                new_graph = html.Img(src=input_data["fig"], title=from_agent_name)
-            elif input_data["mode"] == "mpld3":
-                new_input_data = str(input_data["fig"]).replace("'",'"')
+            if mode == "plotly":
+                new_graph = dcc.Graph(figure=input_data)
+            elif mode == "image":
+                new_graph = html.Img(src=input_data, title=from_agent_name)
+            elif mode == "mpld3":
+                new_input_data = str(input_data).replace("'",'"')
                 new_input_data = new_input_data.replace("(", "[")
                 new_input_data = new_input_data.replace(")", "]")
                 new_input_data = new_input_data.replace("None", "null")
@@ -522,14 +522,15 @@ class Dashboard_agt_net(Dashboard_Layout_Base):
                 for from_agent_name in plot_data:
                     # get the graph relevant to 'monitor_agent_input'
                     graph = plot_data[from_agent_name]
-
+                    print(graph)
                     #handle list of graphs
                     if (isinstance(graph["fig"], tuple) or isinstance(graph["fig"], list) or isinstance(graph["fig"], set)):
-                        for graph_ in graph["fig"]:
-                            new_graph = _handle_matplotlib_figure(graph_, from_agent_name)
+                        for graph_id, graph_ in enumerate(graph["fig"]):
+
+                            new_graph = _handle_matplotlib_figure(graph_, from_agent_name+str(graph_id), graph["mode"])
                             html_div_monitor.append(new_graph)
                     else:
-                        new_graph = _handle_matplotlib_figure(graph, from_agent_name)
+                        new_graph = _handle_matplotlib_figure(graph["fig"], from_agent_name, graph["mode"])
                         html_div_monitor.append(new_graph)
 
                 #only add the graph if there is some plots in the Monitor Agent

--- a/agentMET4FOF/dashboard/assets/render_mpld3.js
+++ b/agentMET4FOF/dashboard/assets/render_mpld3.js
@@ -1,0 +1,54 @@
+function render_mpld3(fig_id, fig_content){
+        function mpld3_load_lib(url, callback){
+          var s = document.createElement('script');
+          s.src = url;
+          s.async = true;
+          s.onreadystatechange = s.onload = callback;
+          s.onerror = function(){console.warn("failed to load library " + url);};
+          document.getElementsByTagName("head")[0].appendChild(s);
+        }
+        if(typeof(mpld3) !== "undefined" && mpld3._mpld3IsLoaded){
+           // already loaded: just create the figure
+           !function(mpld3){
+               d3.select("#"+fig_id).selectAll("*").remove();
+               mpld3.draw_figure(fig_id, fig_content)
+           }(mpld3);
+        }else if(typeof define === "function" && define.amd){
+           // require.js is available: use it to load d3/mpld3
+           require.config({paths: {d3: "https://d3js.org/d3.v5"}});
+           require(["d3"], function(d3){
+              window.d3 = d3;
+              mpld3_load_lib("https://mpld3.github.io/js/mpld3.v0.5.1.js", function(){
+                 d3.select("#"+fig_id).selectAll("*").remove();
+                 mpld3.draw_figure(fig_id, fig_content)
+              });
+            });
+        }else{
+            // require.js not available: dynamically load d3 & mpld3
+            mpld3_load_lib("https://d3js.org/d3.v5.js", function(){
+                 mpld3_load_lib("https://mpld3.github.io/js/mpld3.v0.5.1.js", function(){
+                     d3.select("#"+fig_id).selectAll("*").remove();
+                       mpld3.draw_figure(fig_id, fig_content)
+                    })
+                 });
+        }
+
+}
+
+if(!window.dash_clientside) {window.dash_clientside = {};}
+window.dash_clientside.clientside = {
+    render_mpld3_each: function(value){
+        for (mpld3_children of value[0].props.children) {
+            if ("id" in mpld3_children.props && mpld3_children.type == "Div") {
+                fig_id = mpld3_children.props.id
+                if (fig_id.includes("d3_"))
+                {
+                fig_content = JSON.parse(mpld3_children.props.children.props.children)
+                render_mpld3(fig_id, fig_content)
+                }
+                }
+        }
+        return 0
+    }
+}
+

--- a/agentMET4FOF/dashboard/assets/render_mpld3.js
+++ b/agentMET4FOF/dashboard/assets/render_mpld3.js
@@ -38,6 +38,7 @@ function render_mpld3(fig_id, fig_content){
 if(!window.dash_clientside) {window.dash_clientside = {};}
 window.dash_clientside.clientside = {
     render_mpld3_each: function(value){
+//        console.log(value)
         for (mpld3_children of value[0].props.children) {
             if ("id" in mpld3_children.props && mpld3_children.type == "Div") {
                 fig_id = mpld3_children.props.id

--- a/agentMET4FOF_tutorials/plotting/basic_memory_plot.py
+++ b/agentMET4FOF_tutorials/plotting/basic_memory_plot.py
@@ -1,0 +1,93 @@
+#We can plot matplotlib figures or plotly figures in two ways:
+#Plots can only be rendered on the Dashboard via the MonitorAgent
+
+#1. Through a the MonitorAgent's memory
+#   The plot data is obtained from the MonitorAgent's memory, which is a buffering collecting data from input agents. A custom plot function can be provided through the MonitorAgent
+#   handle the data which is specific to context.
+#2. Directly via send_plot()
+#   An agent can construct a plot within itself and send it directly to the MonitorAgent.
+
+#In this first tutorial, we'll show how to do it via method 1. Plotting through the MonitorAgent's buffer which is the simplest to plot
+#We'll first need to understand the MonitorAgent's buffer data structure which is used specifically for plotting.
+#The buffer is a dictionary which incrementally appends datastream from each Input Agent
+
+#We instantiate two generator agents which sends out 1. a dictonary of data, and 2. a list to a MonitorAgent
+#After a while of running this example, you will see the MonitorAgent's memory in the console log:
+# (MonitorAgent_1): Memory: {'SineGeneratorAgent_1': {'Sensor1': array([0.        , 0.47942554]), 'Sensor2': array([1.1 , 1.57942554])},
+# 'SineGeneratorAgent_2': array([0.])}
+
+#As we observe the memory dict structure, we note the keys are the names of input agents,
+#and the values are the content of messages being appended incrementally into its buffer.
+#Here, the content of messages can be either dict of arrays (acceptable are numpy arrays, list, pandas DataFrame), or a single array.
+#Note that due to the agents' asynchronous activity, the length of values can differ.
+
+from agentMET4FOF.agents import AgentMET4FOF, AgentNetwork, MonitorAgent
+from agentMET4FOF.streams import SineGenerator
+
+class SineGeneratorAgent(AgentMET4FOF):
+    """An agent streaming a sine signal
+
+    Takes samples from the :py:mod:`SineGenerator` and pushes them sample by sample
+    to connected agents via its output channel.
+    """
+
+    # The datatype of the stream will be SineGenerator.
+    _sine_stream: SineGenerator
+
+    def init_parameters(self, nested_output=False, scaler=1.0):
+        """Initialize the input data
+
+        Initialize the input data stream as an instance of the
+        :py:mod:`SineGenerator` class
+        """
+        self._sine_stream = SineGenerator()
+        self.nested_output = nested_output
+        self.scaler = scaler
+    def agent_loop(self):
+        """Model the agent's behaviour
+
+        On state *Running* the agent will extract sample by sample the input data
+        streams content and push it via invoking :py:method:`AgentMET4FOF.send_output`.
+        """
+        if self.current_state == "Running":
+            sine_data = self._sine_stream.next_sample()  # dictionary
+
+            if self.nested_output:
+                self.send_output({"Sensor1":sine_data["x"]*self.scaler,"Sensor2":sine_data["x"]*self.scaler+1.1})
+            else:
+                self.send_output(sine_data["x"]*self.scaler)
+
+
+
+def demonstrate_generator_agent_use():
+    # Start agent network server.
+    agent_network = AgentNetwork()
+
+    # Initialize agents by adding them to the agent network.
+    gen_agent = agent_network.add_agent(agentType=SineGeneratorAgent)
+    gen_agent.init_parameters(nested_output=True, scaler=1.0)
+    gen_agent_2 = agent_network.add_agent(agentType=SineGeneratorAgent)
+    gen_agent_2.init_parameters(nested_output=False, scaler=2.0)
+
+    monitor_agent = agent_network.add_agent(agentType=MonitorAgent)
+
+    #Connect the agents
+    agent_network.bind_agents(gen_agent, monitor_agent)
+    agent_network.bind_agents(gen_agent_2, monitor_agent)
+
+    # Set all agents' states to "Running".
+    agent_network.set_running_state()
+
+    # Allow for shutting down the network after execution
+    return agent_network
+
+
+if __name__ == "__main__":
+    demonstrate_generator_agent_use()
+
+
+
+
+
+
+

--- a/agentMET4FOF_tutorials/plotting/basic_send_plot.py
+++ b/agentMET4FOF_tutorials/plotting/basic_send_plot.py
@@ -1,0 +1,82 @@
+#Instead of providing the plot function through the MonitorAgent,
+#Another way is by using the agent's send_plot() function which accepts any matplotlib figure (or list of matplotlib figures) as argument
+#It first converts the figure into any of the 3 formats : image png (default), plotly figure, mpld3 figure
+#Then it sends the converted figure to the MonitorAgent to be rendered on Dashboard
+#Note: Each agent should only use one way of plotting mechanism, the MonitorAgent at the receiving end will override the latest received figure
+#Here, we demonstrate all 3 ways of rendering the same matplotlib figure on randomly generated data.
+#There are technical differences and tradeoffs of interactivity vs integrity between all 3 ways:
+#"image" mode will work for all types of plot with zero interactivity
+#"plotly" mode will not work for all types of plot although it provides most interactivity
+#"mpld3" mode works for most plots, with medium interactivity
+
+from agentMET4FOF.agents import AgentMET4FOF, AgentNetwork, MonitorAgent
+import matplotlib.pyplot as plt
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+
+class RandomGeneratorAgent(AgentMET4FOF):
+    """
+    This agent generates random data and sends out
+    """
+    def agent_loop(self):
+        if self.current_state == "Running":
+            random_data = np.random.randn(1000)
+            self.send_output(random_data)
+
+
+class PlottingAgent(AgentMET4FOF):
+    """
+    Sends out matplotlib figures using send_plot function which uses any plot mode of the available mechanisms to be rendered:
+    "image", "plotly" or "mpld3"
+
+    """
+    def init_parameters(self, plot_mode:str="image"):
+        self.plot_mode=plot_mode
+
+    def on_received_message(self, message):
+        fig = self.plot_time_series(data=message['data'], title=message['from']+'->'+self.name)
+        self.send_plot(fig,mode=self.plot_mode)
+        plt.close(fig)
+
+    def plot_time_series(self, data, title=""):
+        fig= plt.figure()
+        plt.plot(data)
+        plt.title(title)
+        return fig
+
+def main():
+    # start agent network server
+    agentNetwork = AgentNetwork()
+
+    # init agents
+    gen_agent = agentNetwork.add_agent(agentType=RandomGeneratorAgent)
+    plotting_image_agent = agentNetwork.add_agent(agentType=PlottingAgent, name="Plot_image")
+    plotting_plotly_agent = agentNetwork.add_agent(agentType=PlottingAgent, name="Plot_plotly")
+    plotting_mpld3_agent = agentNetwork.add_agent(agentType=PlottingAgent, name="Plot_mpld3")
+    monitor_agent = agentNetwork.add_agent(agentType=MonitorAgent)
+
+    #init parameters
+    plotting_image_agent.init_parameters(plot_mode="image")
+    plotting_plotly_agent.init_parameters(plot_mode="plotly")
+    plotting_mpld3_agent.init_parameters(plot_mode="mpld3")
+
+    #bind agents
+    agentNetwork.bind_agents(gen_agent, plotting_image_agent)
+    agentNetwork.bind_agents(gen_agent, plotting_plotly_agent)
+    agentNetwork.bind_agents(gen_agent, plotting_mpld3_agent)
+    agentNetwork.bind_agents(plotting_image_agent, monitor_agent)
+    agentNetwork.bind_agents(plotting_plotly_agent, monitor_agent)
+    agentNetwork.bind_agents(plotting_mpld3_agent, monitor_agent)
+
+    # set all agents states to "Running"
+    agentNetwork.set_running_state()
+
+    # allow for shutting down the network after execution
+    return agentNetwork
+
+
+if __name__ == '__main__':
+    main()
+
+

--- a/agentMET4FOF_tutorials/plotting/custom_memory_plot.py
+++ b/agentMET4FOF_tutorials/plotting/custom_memory_plot.py
@@ -1,3 +1,13 @@
+#Extending the mechanism of plotting from MonitorAgent's data memory, custom plot function can be provided via the MonitorAgent which are in the form of plotly graph objects
+#This example is derived from Tutorial 1, but the SineGeneratorAgent now provides an additional timestamp field in sending out
+#the data to the MonitorAgent
+#By providing a `custom_plot_function` function to the MonitorAgent, together with any named parameters for the plotting,
+#the dashboard will read and run these functions with the provided parameters
+
+#To define a custom function, the first two parameters are mandatory namely `data` and `label`
+#while any number of additional user-defined keyword arguments can be supplied arbitrarily
+#The function needs to return either a single plotly figure, or a list of plotly figures.
+
 from agentMET4FOF.agents import AgentMET4FOF, AgentNetwork, MonitorAgent
 from agentMET4FOF.streams import SineGenerator
 
@@ -5,16 +15,7 @@ import numpy as np
 import plotly.graph_objs as go
 from datetime import datetime
 
-#Custom plots can be provided via the MonitorAgent which are in the form of plotly graph objects
-#This example is derived from Tutorial 1, but the SineGeneratorAgent now provides an additional timestamp field in sending out
-#the data to the MonitorAgent
-#By providing a `custom_plot_function` function to the MonitorAgent, together with any named parameters for the plotting,
-#the dashboard will read and run these functions with the provided parameters
-
-#To define a custom function, the first two parameters are mandatory namely `data` and `label`
-#The following parameters are user-defined keyword arguments
-
-def custom_create_monitor_graph(data, sender_agent, xname=0,yname=0):
+def custom_create_monitor_graph(data, sender_agent, xname='Time',yname='Y'):
     """
     Parameters
     ----------
@@ -74,6 +75,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-
-

--- a/agentMET4FOF_tutorials/plotting/list_of_plots.py
+++ b/agentMET4FOF_tutorials/plotting/list_of_plots.py
@@ -1,0 +1,92 @@
+#Using any of the two mechanism of plotting in the previous tutorials: basic_memory_plot.py and basic_send_plot.py,
+#instead of a single plot, we can provide a list of plots to be rendered
+#In this example, the PlottingAgent generates two plots: 1. raw time series and 2. correlation matrix of the sensors datastream
+#This also demonstrates the limitation of the 3 types of plotting mechanisms chosen
+
+
+from agentMET4FOF.agents import AgentMET4FOF, AgentNetwork, MonitorAgent
+import matplotlib.pyplot as plt
+import numpy as np
+import matplotlib
+import pandas as pd
+matplotlib.use('Agg')
+
+class RandomGeneratorAgent(AgentMET4FOF):
+    """
+    This agent generates random multisensor data and sends out
+    """
+    def agent_loop(self):
+        if self.current_state == "Running":
+            sensor_1_random_data = np.random.randn(1000)
+            sensor_2_random_data = sensor_1_random_data + np.random.randn(1000)*0.15
+            sensor_dataframe = pd.DataFrame({'Sensor1':sensor_1_random_data, 'Sensor2':sensor_2_random_data})
+            self.send_output(sensor_dataframe)
+
+
+class PlottingAgent(AgentMET4FOF):
+    """
+    Sends out matplotlib figures using send_plot function which uses any plot mode of the available mechanisms to be rendered:
+    "image", "plotly" or "mpld3"
+
+    """
+    def init_parameters(self, plot_mode:str="image"):
+        self.plot_mode=plot_mode
+
+    def on_received_message(self, message):
+        time_series_fig = self.plot_time_series(data=message['data'], title=message['from']+'->'+self.name)
+        correlation_fig = self.plot_correlation(data=message['data'], title=message['from']+'->'+self.name)
+
+        self.send_plot([time_series_fig,correlation_fig],mode=self.plot_mode)
+        plt.close(time_series_fig)
+        plt.close(correlation_fig)
+
+    def plot_time_series(self, data, title=""):
+        fig= plt.figure()
+        plt.plot(data['Sensor1'])
+        plt.plot(data['Sensor2'])
+        plt.title(title)
+        plt.legend(list(data.columns))
+        return fig
+
+    def plot_correlation(self, data, title=""):
+        fig, ax = plt.subplots()
+        ax.matshow(data.corr())
+        plt.title(title)
+        return fig
+
+def main():
+    # start agent network server
+    agentNetwork = AgentNetwork()
+
+    # init agents
+    gen_agent = agentNetwork.add_agent(agentType=RandomGeneratorAgent)
+    plotting_image_agent = agentNetwork.add_agent(agentType=PlottingAgent, name="Plot_image")
+    plotting_plotly_agent = agentNetwork.add_agent(agentType=PlottingAgent, name="Plot_plotly")
+    plotting_mpld3_agent = agentNetwork.add_agent(agentType=PlottingAgent, name="Plot_mpld3")
+    monitor_agent = agentNetwork.add_agent(agentType=MonitorAgent)
+
+    #init parameters
+    plotting_image_agent.init_parameters(plot_mode="image")
+    plotting_plotly_agent.init_parameters(plot_mode="plotly")
+    plotting_mpld3_agent.init_parameters(plot_mode="mpld3")
+
+    #bind agents
+    agentNetwork.bind_agents(gen_agent, plotting_image_agent)
+    agentNetwork.bind_agents(gen_agent, plotting_plotly_agent)
+    agentNetwork.bind_agents(gen_agent, plotting_mpld3_agent)
+    agentNetwork.bind_agents(plotting_image_agent, monitor_agent)
+    agentNetwork.bind_agents(plotting_plotly_agent, monitor_agent)
+    agentNetwork.bind_agents(plotting_mpld3_agent, monitor_agent)
+
+    # set all agents states to "Running"
+    agentNetwork.set_running_state()
+
+    # allow for shutting down the network after execution
+    return agentNetwork
+
+
+if __name__ == '__main__':
+    main()
+
+
+


### PR DESCRIPTION
Now we can do : agent.send_plot(matplotlib.Figure, mode="mpld3")

This is a working edition , compared to the previous pull request  (https://github.com/bangxiangyong/agentMET4FOF/pull/56) which was left as a draft pull and its code base version was too far behind. 



