### PR TITLE
Introduce more levels in documentation menus on ReadTheDocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,13 @@ extensions = [
     "recommonmark",
 ]
 
+# ReadTheDocs Sphinx theme option taken from
+# https://sphinx-rtd-theme.readthedocs.io/en/latest/configuring.html
+html_theme_options = {
+    # True hides the + signs to expand the menu entries in the sidebar.
+    'collapse_navigation': False,
+}
+
 nbsphinx_allow_errors = True
 
 ################################################################################


### PR DESCRIPTION
This should resolve #123 .

Checkout the ["new" docs](https://agentmet4fof.readthedocs.io/en/improve_docs/agentMET4FOF_tutorials/tutorial_1_generator_agent.html) with the little :heavy_plus_sign: next to the heading in the sidebar.