### PR TITLE
Raise timeout in pytest's conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from agentMET4FOF.agents import AgentNetwork
 
 # Set time to wait for before agents should have done their jobs in networks.
-test_timeout = 8
+test_timeout = 10
 
 # Set random seed to achieve reproducibility
 np.random.seed(123)


### PR DESCRIPTION
Our test were failing sometimes. We needed to raise the timeout for our tests to allow for proper shutdown of our networks.