### PR TITLE
Improve readability of tutorial 4's plot

### DIFF
--- a/agentMET4FOF_tutorials/tutorial_4_metrological_streams.py
+++ b/agentMET4FOF_tutorials/tutorial_4_metrological_streams.py
@@ -60,7 +60,7 @@ def demonstrate_metrological_stream():
 
     # Initialize metrologically enabled plotting agent.
     monitor_agent = agent_network.add_agent(
-        "MonitorAgent", agentType=MetrologicalMonitorAgent
+        "MonitorAgent", agentType=MetrologicalMonitorAgent, buffer_size=50,
     )
 
     # Bind agents.


### PR DESCRIPTION
This keeps the amount of datapoints being shown in the plot on less or equal 50. That greatly improves readability after some few seconds of execution time. What do you think?